### PR TITLE
Allow category method name prefix to be specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,8 @@ xcuserdata
 
 # Also, ignore .xccheckout files, as they contain data about specific paths and remotes that doesn't feel right in the repo. -igreensp 20131230
 *.xccheckout
+
+####
+# AppCode
+.idea
+

--- a/Cat2Cat/VICatalogWalker.h
+++ b/Cat2Cat/VICatalogWalker.h
@@ -26,6 +26,7 @@ typedef NS_OPTIONS(NSUInteger, VICatalogWalkerOutputType) {
 
 @interface VICatalogWalkerParameters : NSObject
 @property (nonatomic, strong) NSArray *assetCatalogPaths;
+@property (nonatomic, strong) NSString *methodNamePrefix;
 @property (nonatomic, strong) NSString *outputDirectory;
 @property (nonatomic, assign) VICatalogWalkerOutputType outputTypes;
 @end

--- a/Cat2Cat/VICatalogWalker.m
+++ b/Cat2Cat/VICatalogWalker.m
@@ -38,7 +38,8 @@ static NSString *const ExtensionStandardImageset = @".imageset";
     BOOL success = YES;
     
     VOKTemplateModel *model = [self modelForFullCatalogPaths:parameters.assetCatalogPaths];
-    
+    model.methodNamePrefix = parameters.methodNamePrefix;
+
     if (parameters.outputTypes & VICatalogWalkerOutputObjCIOS) {
         success = success && [self writeHandMFilesForPlatform:VOKTemplatePlatformIOS model:model];
     }

--- a/Cat2Cat/main.m
+++ b/Cat2Cat/main.m
@@ -15,8 +15,8 @@
 
 static VICatalogWalkerParameters *parametersFromLegacyArguments(int argc, const char * argv[]);
 static VICatalogWalkerParameters *parametersFromArguments(int argc, const char * argv[]);
-BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error);
-void exitWithLaunchArgAndError(const char *launchArg, NSError *error);
+static BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error);
+static void exitWithLaunchArgAndError(const char *launchArg, NSError *error);
 
 int main(int argc, const char * argv[])
 {
@@ -228,7 +228,7 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
     return parameters;
 }
 
-BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error)
+static BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error)
 {
     if ([methodNamePrefix length] < 2) {
         *error = [NSError errorWithDomain:@"Cat2Cat" code:-1 userInfo:@{ NSLocalizedDescriptionKey : @"Method name prefix must be at least 2 characters." }];
@@ -243,7 +243,7 @@ BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error)
     return *error == nil;
 }
 
-void exitWithLaunchArgAndError(const char *launchArg, NSError *error)
+static void exitWithLaunchArgAndError(const char *launchArg, NSError *error)
 {
     const char * message = [[error localizedDescription] UTF8String];
     fprintf(stderr, "%s: %s\n", launchArg, message);

--- a/Cat2Cat/main.m
+++ b/Cat2Cat/main.m
@@ -16,7 +16,7 @@
 static VICatalogWalkerParameters *parametersFromLegacyArguments(int argc, const char * argv[]);
 static VICatalogWalkerParameters *parametersFromArguments(int argc, const char * argv[]);
 static BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error);
-static void exitWithLaunchArgAndError(const char *launchArg, NSError *error);
+static void exitWithCommandNameAndError(const char *launchArg, NSError *error);
 
 int main(int argc, const char * argv[])
 {
@@ -188,11 +188,11 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
     
     NSError *error = nil;
     if (![options parseArgc:argc argv:argv error:&error]) {
-        exitWithLaunchArgAndError(argv[0], error);
+        exitWithCommandNameAndError(argv[0], error);
     }
 
     if (methodNamePrefix && !validateMethodNamePrefix(methodNamePrefix, &error)) {
-        exitWithLaunchArgAndError(argv[0], error);
+        exitWithCommandNameAndError(argv[0], error);
     }
     
     VICatalogWalkerParameters *parameters = [[VICatalogWalkerParameters alloc] init];
@@ -243,7 +243,7 @@ static BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error
     return *error == nil;
 }
 
-static void exitWithLaunchArgAndError(const char *launchArg, NSError *error)
+static void exitWithCommandNameAndError(const char *launchArg, NSError *error)
 {
     const char * message = [[error localizedDescription] UTF8String];
     fprintf(stderr, "%s: %s\n", launchArg, message);

--- a/Cat2Cat/main.m
+++ b/Cat2Cat/main.m
@@ -15,6 +15,8 @@
 
 static VICatalogWalkerParameters *parametersFromLegacyArguments(int argc, const char * argv[]);
 static VICatalogWalkerParameters *parametersFromArguments(int argc, const char * argv[]);
+BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error);
+void exitWithLaunchArgAndError(const char *launchArg, NSError *error);
 
 int main(int argc, const char * argv[])
 {
@@ -128,10 +130,11 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
     
     NSString *basePath = [[NSFileManager defaultManager] currentDirectoryPath];
     NSMutableArray *rawAssetCatalogs = [NSMutableArray array];
+    NSString __block *methodNamePrefix = nil;
     NSString *outputDirectory = @"";
-    
+
     BRLOptionParser *options = [[BRLOptionParser alloc] init];
-    
+
     [options addOption:"base-path"
                   flag:'p'
            description:@"Base path used for interpreting the asset catalogs and output directory"
@@ -142,6 +145,12 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
      blockWithArgument:^(NSString *value) {
          [rawAssetCatalogs addObject:value];
      }];
+    [options addOption:"method-name-prefix"
+                  flag:'m'
+           description:@"Prefix for method names (defaults to ac)"
+     blockWithArgument:^(NSString *value) {
+        methodNamePrefix = [value copy];
+    }];
     [options addOption:"output-dir"
                   flag:'o'
            description:@"Output directory"
@@ -179,9 +188,11 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
     
     NSError *error = nil;
     if (![options parseArgc:argc argv:argv error:&error]) {
-        const char * message = [[error localizedDescription] UTF8String];
-        fprintf(stderr, "%s: %s\n", argv[0], message);
-        exit(EXIT_FAILURE);
+        exitWithLaunchArgAndError(argv[0], error);
+    }
+
+    if (methodNamePrefix && !validateMethodNamePrefix(methodNamePrefix, &error)) {
+        exitWithLaunchArgAndError(argv[0], error);
     }
     
     VICatalogWalkerParameters *parameters = [[VICatalogWalkerParameters alloc] init];
@@ -207,10 +218,34 @@ static VICatalogWalkerParameters *parametersFromArguments(int argc, const char *
         [assetCatalogPaths addObjectsFromArray:filesMatchingPattern(url.path)];
     }
     parameters.assetCatalogPaths = assetCatalogPaths;
-    
+
+    parameters.methodNamePrefix = methodNamePrefix;
+
     NSURL *outputUrl = [NSURL URLWithString:[outputDirectory stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]
                               relativeToURL:basePathUrl];
     parameters.outputDirectory = outputUrl.path;
     
     return parameters;
+}
+
+BOOL validateMethodNamePrefix(NSString *methodNamePrefix, NSError **error)
+{
+    if ([methodNamePrefix length] < 2) {
+        *error = [NSError errorWithDomain:@"Cat2Cat" code:-1 userInfo:@{ NSLocalizedDescriptionKey : @"Method name prefix must be at least 2 characters." }];
+    } else {
+        NSMutableCharacterSet *charSet = [[NSCharacterSet letterCharacterSet] mutableCopy];
+        [charSet addCharactersInString:@"_"];
+
+        if ([methodNamePrefix rangeOfCharacterFromSet:[charSet invertedSet]].location != NSNotFound) {
+            *error = [NSError errorWithDomain:@"Cat2Cat" code:-1 userInfo:@{ NSLocalizedDescriptionKey : @"Method name prefix contains invalid characters." }];
+        }
+    }
+    return *error == nil;
+}
+
+void exitWithLaunchArgAndError(const char *launchArg, NSError *error)
+{
+    const char * message = [[error localizedDescription] UTF8String];
+    fprintf(stderr, "%s: %s\n", launchArg, message);
+    exit(EXIT_FAILURE);
 }

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Cat2Cat --base-path="/Users/YourName/Desktop/YourProjectFolder" --asset-catalog=
 
 ```
 Cat2Cat --swift --ios \
-	--base-path="/Users/YourName/Desktop/YourProjectFolder" \
-	--asset-catalog="Resources/*.xcassets" \
+    --base-path="/Users/YourName/Desktop/YourProjectFolder" \
+    --asset-catalog="Resources/*.xcassets" \
     --method-name-prefix="xyz" \
-	--output-dir="Categories"
+    --output-dir="Categories"
 ```
 
 Please see the [iOS Example App](SampleiOSApp)'s `Cat2Cat` aggregate build target for the appropriate run script for iOS only, and the [Mac Example App](SampleMacApp)'s `Cat2Cat` aggregate build target for the appropriate run script for Mac only. 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 Cat2Cat (Catalog to Category)
 =========
 ----
-`Cat2Cat` exists to help solve the typo problem with UIImage's `imageNamed:` method.
+`Cat2Cat` exists to help solve the typo problem with UIImage's `imageNamed:` method. 
 
-Without `Cat2Cat`, you can be left wondering where your background image named `backgroundImage` is, only to discover that you've set up a `[UIImage imageNamed:@"backrgoundImage"];` call by accident.
+Without `Cat2Cat`, you can be left wondering where your background image named `backgroundImage` is, only to discover that you've set up a `[UIImage imageNamed:@"backrgoundImage"];` call by accident. 
 
 With the advent of the Asset Catalog in Xcode 5, there was a huge step in the right direction - images ceased to be tied to their filenames, and it became straightforward to centralize your image assets.
 
-That nasty typo problem, however, still persisted. Until now.
+That nasty typo problem, however, still persisted. Until now. 
 
-`Cat2Cat` goes through provided Asset Catalog files and writes out their contents to a **UIImage+AssetCatalog** or **NSImage+AssetCatalog** category - each `.imageset` within an asset catalog will get its own method to call it, prefixed by `ac_` to indicate the method is from the asset catalog and to help prevent any namespace collisions.
+`Cat2Cat` goes through provided Asset Catalog files and writes out their contents to a **UIImage+AssetCatalog** or **NSImage+AssetCatalog** category - each `.imageset` within an asset catalog will get its own method to call it, prefixed by `ac_` to indicate the method is from the asset catalog and to help prevent any namespace collisions. 
 
-After running `Cat2Cat` and adding the category or categories it produces, instead of calling `[UIImage imageNamed:@"backgroundImage"]`, you can now call `[UIImage ac_backgroundImage]` ensuring that you're always going to get the image you think you're getting, and giving you the benefit of autocomplete when you're trying to remember what in the hell you named that icon.
+After running `Cat2Cat` and adding the category or categories it produces, instead of calling `[UIImage imageNamed:@"backgroundImage"]`, you can now call `[UIImage ac_backgroundImage]` ensuring that you're always going to get the image you think you're getting, and giving you the benefit of autocomplete when you're trying to remember what in the hell you named that icon.  
 
 `Cat2Cat` is compatible with Xcode 5 projects which can leverage Asset Catalogs (i.e., iOS 6 and above).
 
@@ -47,10 +47,10 @@ Cat2Cat --base-path="/Users/YourName/Desktop/YourProjectFolder" --asset-catalog=
 
 ```
 Cat2Cat --swift --ios \
-    --base-path="/Users/YourName/Desktop/YourProjectFolder" \
-    --asset-catalog="Resources/*.xcassets" \
-    --method-name-prefix="xyz" \
-    --output-dir="Categories"
+	--base-path="/Users/YourName/Desktop/YourProjectFolder" \
+	--asset-catalog="Resources/*.xcassets" \
+	--method-name-prefix="xyz" \
+	--output-dir="Categories"
 ```
 
 Please see the [iOS Example App](SampleiOSApp)'s `Cat2Cat` aggregate build target for the appropriate run script for iOS only, and the [Mac Example App](SampleMacApp)'s `Cat2Cat` aggregate build target for the appropriate run script for Mac only. 

--- a/Templating/VOKTemplateModel.h
+++ b/Templating/VOKTemplateModel.h
@@ -15,6 +15,8 @@ typedef NS_ENUM(NSUInteger, VOKTemplatePlatform) {
 
 @interface VOKTemplateModel : NSObject
 
+@property (nonatomic, strong) NSString *methodNamePrefix;
+
 + (instancetype)templateModelWithFolders:(NSArray *)folders;
 
 + (NSString *)classNameForPlatform:(VOKTemplatePlatform)platform;

--- a/Templating/VOKTemplateModel.m
+++ b/Templating/VOKTemplateModel.m
@@ -25,7 +25,7 @@ static NSString *const ClassNameMac = @"NSImage";
 static NSString *const KitNameIOS = @"UIKit";
 static NSString *const KitNameMac = @"AppKit";
 
-static NSString *const FrameworkPrefix = @"ac_";
+static NSString *const MethodNamePrefix = @"ac";
 static NSString *const ConstantStructName = @"Cat2CatImageNames";
 
 static NSString *const SwiftEnumName = @"Cat2CatImageName";
@@ -88,7 +88,7 @@ static NSString *const SwiftEnumName = @"Cat2CatImageName";
     
     // Construct the additional context.
     NSMutableDictionary *context = [@{
-                                      @"frameworkPrefix": FrameworkPrefix,
+                                      @"methodNamePrefix": self.methodNamePrefix ?: MethodNamePrefix,
                                       @"constantStructName": ConstantStructName,
                                       @"swiftEnumName": SwiftEnumName,
                                       @"fileName": path.lastPathComponent,

--- a/Templating/templates/ObjC.h.methods.mustache
+++ b/Templating/templates/ObjC.h.methods.mustache
@@ -1,9 +1,9 @@
 #pragma mark - {{ name }}
 
-{{# isMac }}{{# icons }}+ ({{ imageClass }} *){{ frameworkPrefix }}{{ method }};
+{{# isMac }}{{# icons }}+ ({{ imageClass }} *){{ methodNamePrefix }}_{{ method }};
 
 {{/ icons }}{{/ isMac }}{{!
-}}{{# images }}+ ({{ imageClass }} *){{ frameworkPrefix }}{{ method }};
+}}{{# images }}+ ({{ imageClass }} *){{ methodNamePrefix }}_{{ method }};
 
 {{/ images }}{{!
 }}{{# subfolders }}{{> ObjC.h.methods }}{{/ subfolders }}

--- a/Templating/templates/ObjC.m.methods.mustache
+++ b/Templating/templates/ObjC.m.methods.mustache
@@ -1,12 +1,12 @@
 #pragma mark - {{ name }}
 
-{{# isMac }}{{# icons }}+ ({{ imageClass }} *){{ frameworkPrefix }}{{ method }}
+{{# isMac }}{{# icons }}+ ({{ imageClass }} *){{ methodNamePrefix }}_{{ method }}
 {
     return [{{ imageClass }} imageNamed:{{ constantStructName }}.{{ method }}];
 }
 
 {{/ icons }}{{/ isMac }}{{!
-}}{{# images }}+ ({{ imageClass }} *){{ frameworkPrefix }}{{ method }}
+}}{{# images }}+ ({{ imageClass }} *){{ methodNamePrefix }}_{{ method }}
 {
     return [{{ imageClass }} imageNamed:{{ constantStructName }}.{{ method }}];
 }

--- a/Templating/templates/swift.methods.mustache
+++ b/Templating/templates/swift.methods.mustache
@@ -1,11 +1,11 @@
     // MARK: - {{ name }}
     
-{{# isMac }}{{# icons }}    static func {{ frameworkPrefix }}{{ method }}() -> {{ imageClass }} {
+{{# isMac }}{{# icons }}    static func {{ methodNamePrefix }}_{{ method }}() -> {{ imageClass }} {
         return {{ imageClass }}(c2cName: {{ swiftEnumName }}.{{ method }})
     }
     
 {{/ icons }}{{/ isMac }}{{!
-}}{{# images }}    static func {{ frameworkPrefix }}{{ method }}() -> {{ imageClass }} {
+}}{{# images }}    static func {{ methodNamePrefix }}_{{ method }}() -> {{ imageClass }} {
         return {{ imageClass }}(c2cName: {{ swiftEnumName }}.{{ method }})
     }
     


### PR DESCRIPTION
This PR allows the category method name prefix to be set to something other than `ac`. When the prefix matches what other categories are using in a project, it makes it clear that the category belongs to that project, and was not imported via an external framework. Also, in the case where several asset catalogs exist in a project, it can be useful to use a different prefix for each one. If no prefix is specified, the default `ac` is used.